### PR TITLE
Upload.api_delete_data_file : on retire data/ si l'utilisateur ne l'a pas fait

### DIFF
--- a/ignf_gpf_api/store/Upload.py
+++ b/ignf_gpf_api/store/Upload.py
@@ -54,10 +54,15 @@ class Upload(TagInterface, CommentInterface, SharingInterface, EventInterface, P
 
     def api_delete_data_file(self, api_path: str) -> None:
         """Supprime un fichier de donnée de la livraison.
+        Retire data/ de devant le chemin si jamais il le contient.
 
         Args:
             api_path (str): chemin distant vers le fichier à supprimer
         """
+        # On retire data/ de devant le chemin si jamais il le contient
+        if api_path.startswith("data/"):
+            api_path = api_path[5:]
+
         # Génération du nom de la route
         s_route = f"{self._entity_name}_delete_data"
 

--- a/tests/store/UploadTestCase.py
+++ b/tests/store/UploadTestCase.py
@@ -76,8 +76,8 @@ class UploadTestCase(unittest.TestCase):
                 # Vérification sur o_mock_open (lecture binary)
                 o_mock_open.assert_called_once_with("rb")
 
-    def test_api_delete_data_file(self) -> None:
-        "Vérifie le bon fonctionnement de api_delete_data_file."
+    def test_api_delete_data_file_1(self) -> None:
+        "Vérifie le bon fonctionnement de api_delete_data_file si le chemin ne contient pas data/."
         # On instancie une livraison pour laquelle on veut supprimer des fichiers
         # peu importe si la livraison comporte ou pas des fichiers
         o_upload = Upload({"_id": "id_de_test"})
@@ -96,6 +96,28 @@ class UploadTestCase(unittest.TestCase):
                 method=ApiRequester.DELETE,
                 route_params={"upload": "id_de_test"},
                 params={"path": s_api_path},
+            )
+
+    def test_api_delete_data_file_2(self) -> None:
+        "Vérifie le bon fonctionnement de api_delete_data_file si le chemin contient data/."
+        # On instancie une livraison pour laquelle on veut supprimer des fichiers
+        # peu importe si la livraison comporte ou pas des fichiers
+        o_upload = Upload({"_id": "id_de_test"})
+        # on prend un chemin coté api
+        s_api_path = "data/path/cote/api"
+
+        # On mock la fonction request, on veut vérifier qu'elle est appelée avec les bons params
+        o_api_requester = ApiRequester()
+        with patch.object(o_api_requester, "route_request", return_value=None) as o_mock_request:
+            # On appelle la fonction que l'on veut tester
+            o_upload.api_delete_data_file(s_api_path)
+
+            # Vérification sur o_mock_request
+            o_mock_request.assert_called_once_with(
+                "upload_delete_data",
+                method=ApiRequester.DELETE,
+                route_params={"upload": "id_de_test"},
+                params={"path": s_api_path[5:]},  # le data/ a dû être retiré
             )
 
     def test_api_delete_md5_file(self) -> None:


### PR DESCRIPTION
le chemin des fichiers qu'on on les liste contient "data/" alors que pour les supprimer, il faut enlever ce "data/".

J'ai modifié la fonction pour qu'elle le fasse si besoin.