### PR TITLE
UploadAction.monitor_until_end devient une méthode statique

### DIFF
--- a/ignf_gpf_api/__main__.py
+++ b/ignf_gpf_api/__main__.py
@@ -161,7 +161,7 @@ def upload(o_args: argparse.Namespace) -> None:
         for o_dataset in o_dfu.datasets:
             o_ua = UploadAction(o_dataset, behavior=o_args.behavior)
             o_upload = o_ua.run()
-            if o_ua.monitor_until_end(print):
+            if UploadAction.monitor_until_end(o_upload, print):
                 print(f"Livraison {o_upload} créée avec succès.")
             else:
                 print(f"Livraison {o_upload} créée en erreur !")

--- a/ignf_gpf_api/workflow/action/UploadAction.py
+++ b/ignf_gpf_api/workflow/action/UploadAction.py
@@ -140,45 +140,51 @@ class UploadAction:
         # sinon on retourne None
         return None
 
-    def monitor_until_end(self, callback: Optional[Callable[[str], None]] = None) -> Optional[bool]:
-        """Attend que chaque vérification soit terminée (en erreur ou en échec) avant de rendre la main.
-        La fonction callback indiquée est exécutée en prenant en paramètre un message de suivi du nombre de vérifications par statuts.
+    @property
+    def upload(self) -> Optional[Upload]:
+        return self.__upload
+
+    @staticmethod
+    def monitor_until_end(upload: Upload, callback: Optional[Callable[[str], None]] = None) -> bool:
+        """Attend que toute les vérifications liées à la Livraison indiquée soient terminées (en erreur ou en succès) avant de rendre la main.
+        La fonction callback indiquée est exécutée en prenant en paramètre un message de suivi du nombre de vérifications par statut.
 
         Args:
+            upload (Upload): Livraison à monitorer
             callback (Optional[Callable[[str], None]]): fonction de callback à exécuter avec le message de suivi. Defaults to None.
 
         Returns:
-            Optional[bool]: True si toutes les vérifications sont ok, sinon False
+            bool: True si toutes les vérifications sont ok, sinon False
         """
         i_nb_sec_between_check = Config().get_int("upload_creation", "nb_sec_between_check_updates")
         s_check_message_pattern = Config().get("upload_creation", "check_message_pattern")
         b_success: Optional[bool] = None
         OutputManager().info(f"Monitoring des vérifications toutes les {i_nb_sec_between_check} secondes...")
-        if self.__upload is not None:
-            while b_success is None:
-                # On récupère les vérifications
-                d_checks = self.__upload.api_list_checks()
-                # On peut déterminer b_success s'il n'y en a plus en attente et en cours
-                if len(d_checks["asked"]) == len(d_checks["in_progress"]) == 0:
-                    b_success = len(d_checks["failed"]) == 0
-                # On affiche un rapport via la fonction de callback précisée
-                s_message = s_check_message_pattern.format(
-                    nb_asked=len(d_checks["asked"]),
-                    nb_in_progress=len(d_checks["in_progress"]),
-                    nb_passed=len(d_checks["passed"]),
-                    nb_failed=len(d_checks["failed"]),
-                )
-                if callback is not None:
-                    callback(s_message)
+        while b_success is None:
+            # On récupère les vérifications
+            d_checks = upload.api_list_checks()
+            # On peut déterminer b_success s'il n'y en a plus en attente et en cours
+            if len(d_checks["asked"]) == len(d_checks["in_progress"]) == 0:
+                b_success = len(d_checks["failed"]) == 0
+            # On affiche un rapport via la fonction de callback précisée
+            s_message = s_check_message_pattern.format(
+                nb_asked=len(d_checks["asked"]),
+                nb_in_progress=len(d_checks["in_progress"]),
+                nb_passed=len(d_checks["passed"]),
+                nb_failed=len(d_checks["failed"]),
+            )
+            if callback is not None:
+                callback(s_message)
+            # Si l'état est toujours indéterminé
+            if b_success is None:
                 # On attend le temps demandé
                 time.sleep(i_nb_sec_between_check)
-            # Si on est sorti c'est que c'est tout bon
-            # On log le dernier rapport
-            if b_success:
-                Config().om.info(s_message)
-            else:
-                Config().om.warning(s_message)
-        return b_success
+        # On log le dernier rapport selon l'état et on sort
+        if b_success:
+            Config().om.info(s_message)
+            return True
+        Config().om.warning(s_message)
+        return False
 
     @staticmethod
     def parse_tree(tree: List[Dict[str, Any]], prefix: str = "") -> Dict[str, int]:


### PR DESCRIPTION
Passage de la méthode en statique pour pouvoir l'utiliser sans passer par un fichier descriptor nécessaire à instancier le UpoadAction...