### PR TITLE
EventInterface: nom route en accord avec la config

### DIFF
--- a/ignf_gpf_api/store/interface/EventInterface.py
+++ b/ignf_gpf_api/store/interface/EventInterface.py
@@ -14,7 +14,7 @@ class EventInterface(StoreEntity):
             List[Dict[str, Any]]: liste des événements
         """
         # Génération du nom de la route
-        s_route = f"{self._entity_name}_list_event"
+        s_route = f"{self._entity_name}_list_events"
         # Requête "get" à l'API
         o_response = ApiRequester().route_request(
             s_route,

--- a/tests/store/EventInterfaceTestCase.py
+++ b/tests/store/EventInterfaceTestCase.py
@@ -23,7 +23,7 @@ class EventInterfaceTestCase(GpfTestCase):
             l_data_recupere = o_event_interface.api_events()
             # on vérifie que route_request est appelé correctement
             o_mock_request.assert_called_once_with(
-                "store_entity_list_event",
+                "store_entity_list_events",
                 route_params={"store_entity": "id_entité"},
             )
             # on vérifie la similitude des données retournées


### PR DESCRIPTION
bug trouvé avec ticket tuleap [786](https://ign.mytuleap.com/plugins/tracker/?aid=786&planning%5Btaskboard%5D%5B2%5D=795) geo_nettoyage.