### PR TITLE
Classes actions afficher sous string

### DIFF
--- a/ignf_gpf_api/workflow/action/ActionAbstract.py
+++ b/ignf_gpf_api/workflow/action/ActionAbstract.py
@@ -101,3 +101,21 @@ class ActionAbstract(ABC):
                 d_tags[s_tag] = tags[s_tag]
         # On peut maintenant renvoyer les filtres
         return d_infos, d_tags
+
+    ##############################################################
+    # Fonctions de représentation
+    ##############################################################
+    def __str__(self) -> str:
+        # Affichage à destination d'un utilisateur.
+        # On affiche l'id et le nom si possible.
+
+        # Liste pour stocker les infos à afficher
+        l_infos = []
+        # Ajout de l'id
+        l_infos.append(f"workflow={self.workflow_context}")
+        return f"{self.__class__.__name__}({', '.join(l_infos)})"
+
+    def __repr__(self) -> str:
+        # Affichage à destination d'un développeur.
+        # Pour le moment, pas de différence avec __str__
+        return str(self)

--- a/ignf_gpf_api/workflow/action/ProcessingExecutionAction.py
+++ b/ignf_gpf_api/workflow/action/ProcessingExecutionAction.py
@@ -68,12 +68,6 @@ class ProcessingExecutionAction(ActionAbstract):
                 # Comportement de suppression des entités détectées
                 if self.__behavior == self.BEHAVIOR_DELETE:
                     Config().om.warning(f"Une donnée stockée équivalente à {o_stored_data} va être supprimée puis recréée.")
-                    # Config().om.warning("Si une exécution de traitement liée à la donnée équivalente existe, elle sera supprimée.")
-                    # # Récupération des traitements qui ont créé la donnée stockée équivalente
-                    # l_process = ProcessingExecution.api_list(infos_filter={"output_stored_data": o_stored_data.id})
-                    # for o_process in l_process:
-                    #     # Suppression du traitement
-                    #     o_process.api_delete()
                     # Suppression de la donnée stockée
                     o_stored_data.api_delete()
                     # création de la ProcessingExecution
@@ -263,3 +257,18 @@ class ProcessingExecutionAction(ActionAbstract):
         else:
             return False
         return "name" in d_el
+
+    ##############################################################
+    # Fonctions de représentation
+    ##############################################################
+    def __str__(self) -> str:
+        # Affichage à destination d'un utilisateur.
+        # On affiche l'id et le nom si possible.
+
+        # Liste pour stocker les infos à afficher
+        l_infos = []
+        # Ajout de l'id
+        l_infos.append(f"workflow={self.workflow_context}")
+        if self.processing_execution:
+            l_infos.append(f"processing_execution={self.processing_execution.id}")
+        return f"{self.__class__.__name__}({', '.join(l_infos)})"

--- a/tests/workflow/action/ActionAbstractTestCase.py
+++ b/tests/workflow/action/ActionAbstractTestCase.py
@@ -69,3 +69,9 @@ class ActionAbstractTestCase(GpfTestCase):
             # Vérifications critères conservés
             self.assertDictEqual(d_infos, {"info_1": "val_1", "info_2": "val_2"})
             self.assertDictEqual(d_tags, {"tag_3": "val_3"})
+
+    def test_str(self) -> None:
+        """test de __str__"""
+        d_definition = {"test": "val"}
+        o_action = ConcreteAction("nom", d_definition, None)
+        self.assertEqual("ConcreteAction(workflow=nom)", str(o_action))

--- a/tests/workflow/action/ProcessingExecutionActionTestCase.py
+++ b/tests/workflow/action/ProcessingExecutionActionTestCase.py
@@ -328,3 +328,15 @@ class ProcessingExecutionActionTestCase(GpfTestCase):
                 # initialisation de ProcessingExecutionAction
                 o_pea = ProcessingExecutionAction("contexte", d_definition_dict)
                 self.assertEqual(o_pea.output_new_entity, b_new)
+
+
+    def test_str(self) -> None:
+        """test de __str__"""
+        d_definition = {"_id": "ancien"}
+        # test sans processing execution
+        o_action = ProcessingExecutionAction("nom", d_definition)
+        self.assertEqual("ProcessingExecutionAction(workflow=nom)", str(o_action))
+        # test avec processing execution
+        with patch('ignf_gpf_api.workflow.action.ProcessingExecutionAction.ProcessingExecutionAction.processing_execution', new_callable=PropertyMock) as o_mock_processing_execution:
+            o_mock_processing_execution.return_value = MagicMock(id='test uuid')
+            self.assertEqual("ProcessingExecutionAction(workflow=nom, processing_execution=test uuid)", str(o_action))


### PR DESCRIPTION
Ajout fonction `__str__` pour les classes action + tests. Permet un affichage correcte dans les logs.