### PR TITLE
gestion affichage url en prod et en qualif

### DIFF
--- a/ignf_gpf_api/workflow/action/OfferingAction.py
+++ b/ignf_gpf_api/workflow/action/OfferingAction.py
@@ -31,8 +31,13 @@ class OfferingAction(ActionAbstract):
         if o_offering is not None:
             # Récupération des liens
             o_offering.api_update()
-            s_urls = "\n   - ".join([d_url["url"] for d_url in o_offering["urls"]])
-            Config().om.info(f"Offre créée : {self.__offering}\n   - {s_urls}")
+            if len(o_offering["urls"]) > 0 and isinstance(o_offering["urls"][0], dict):
+                # si les url sont récupérer sous forme de dict on affiche l'url uniquement
+                s_urls = "\n   - ".join([d_url["url"] for d_url in o_offering["urls"]])
+            else:
+                # si les url sont récupérer directement
+                s_urls = "\n   - ".join(o_offering["urls"])
+            Config().om.info(f"Offre créée : {self.__offering}\n{s_urls}")
         Config().om.info("Création d'une offre : terminé")
 
     def __create_offering(self) -> None:

--- a/ignf_gpf_api/workflow/action/OfferingAction.py
+++ b/ignf_gpf_api/workflow/action/OfferingAction.py
@@ -32,10 +32,10 @@ class OfferingAction(ActionAbstract):
             # Récupération des liens
             o_offering.api_update()
             if len(o_offering["urls"]) > 0 and isinstance(o_offering["urls"][0], dict):
-                # si les url sont récupérer sous forme de dict on affiche l'url uniquement
+                # si les url sont récupérées sous forme de dict on affiche l'url uniquement
                 s_urls = "\n   - ".join([d_url["url"] for d_url in o_offering["urls"]])
             else:
-                # si les url sont récupérer directement
+                # si les url sont récupérées sous forme de liste
                 s_urls = "\n   - ".join(o_offering["urls"])
             Config().om.info(f"Offre créée : {self.__offering}\n{s_urls}")
         Config().om.info("Création d'une offre : terminé")

--- a/tests/workflow/action/OfferingActionTestCase.py
+++ b/tests/workflow/action/OfferingActionTestCase.py
@@ -54,8 +54,8 @@ class OfferingActionTestCase(GpfTestCase):
         o_mock_offering = MagicMock()
         o_mock_offering.api_launch.return_value = None
 
-        def side_effect(arg: str) -> Any:
-            """side_effect pour récupération des élément de offering, gestion du cas des url qui sont un dictionnaire
+        def side_effect_dict(arg: str) -> Any:
+            """side_effect pour récupération des élément de offering, gestion du cas des url qui sont dans un dictionnaire
 
             Args:
                 arg (str): clef à affiché
@@ -67,18 +67,33 @@ class OfferingActionTestCase(GpfTestCase):
                 return [{"url": "http://1"}, {"url": "http://2"}]
             return "getitem"
 
-        o_mock_offering.__getitem__.side_effect = side_effect
+        def side_effect_text(arg: str) -> Any:
+            """side_effect pour récupération des élément de offering, gestion du cas des url qui sont donné directement
 
-        with patch.object(o_offering_action, "find_offering", return_value=o_mock_offering) as o_mock_offering_action_list_offering:
-            with patch.object(Offering, "api_create", return_value=None) as o_mock_offering_api_create:
-                # on lance l'exécution de run
-                o_offering_action.run()
+            Args:
+                arg (str): clef à affiché
 
-                # test de l'appel à OfferingAction.find_offering
-                o_mock_offering_action_list_offering.assert_called_once()
+            Returns:
+                Any: valeur de retour
+            """
+            if arg == "urls":
+                return ["http://1", "http://2"]
+            return "getitem"
 
-                # test de l'appel à Offering.api_create
-                o_mock_offering_api_create.assert_not_called()
+        for f_effect in [side_effect_dict, side_effect_text]:
+
+            o_mock_offering.__getitem__.side_effect = f_effect
+
+            with patch.object(o_offering_action, "find_offering", return_value=o_mock_offering) as o_mock_offering_action_list_offering:
+                with patch.object(Offering, "api_create", return_value=None) as o_mock_offering_api_create:
+                    # on lance l'exécution de run
+                    o_offering_action.run()
+
+                    # test de l'appel à OfferingAction.find_offering
+                    o_mock_offering_action_list_offering.assert_called_once()
+
+                    # test de l'appel à Offering.api_create
+                    o_mock_offering_api_create.assert_not_called()
 
     def test_find_offering_exists_and_ok(self) -> None:
         """Test de find_offering quand une offering est trouvée et que le endpoint correspond."""


### PR DESCRIPTION
Fixe #90 github et 817 tuleap (doublon)

afffichage des url quand elle sont récupérer sous dorme de liste de str (prod) ou de liste de dict (qualif)