### PR TITLE
Gestion commentaire doublon

### DIFF
--- a/ignf_gpf_api/workflow/action/ConfigurationAction.py
+++ b/ignf_gpf_api/workflow/action/ConfigurationAction.py
@@ -60,9 +60,13 @@ class ConfigurationAction(ActionAbstract):
         """Ajout des commentaires sur la Configuration."""
         # on vérifie que la configuration et definition_dict ne sont pas null et on vérifie qu'il y'a bien une clé comments
         if self.configuration and self.definition_dict and "comments" in self.definition_dict and self.definition_dict["comments"] != {}:
+            # récupération des commentaires déjà ajoutés
+            l_actual_comments = [d_comment["text"] for d_comment in self.configuration.api_list_comments() if d_comment]
             Config().om.info(f"Configuration {self.configuration['name']} : ajout des {len(self.definition_dict['comments'])} commentaires...")
             for s_comment in self.definition_dict["comments"]:
-                self.configuration.api_add_comment({"text": s_comment})
+                # si le commentaire n'existe pas déjà on l'ajoute
+                if s_comment not in l_actual_comments:
+                    self.configuration.api_add_comment({"text": s_comment})
             Config().om.info(f"Configuration {self.configuration['name']} : les {len(self.definition_dict['comments'])} commentaires ont été ajoutés avec succès.")
 
     def find_configuration(self) -> Optional[Configuration]:

--- a/ignf_gpf_api/workflow/action/UploadAction.py
+++ b/ignf_gpf_api/workflow/action/UploadAction.py
@@ -98,8 +98,10 @@ class UploadAction:
         """Ajoute les commentaires."""
         if self.__upload is not None:
             Config().om.info(f"Livraison {self.__upload['name']} : ajout des {len(self.__dataset.comments)} commentaires...")
+            l_actual_comments = [d_comment["text"] for d_comment in self.__upload.api_list_comments() if d_comment]
             for s_comment in self.__dataset.comments:
-                self.__upload.api_add_comment({"text": s_comment})
+                if s_comment not in l_actual_comments:
+                    self.__upload.api_add_comment({"text": s_comment})
             Config().om.info(f"Livraison {self.__upload['name']} : les {len(self.__dataset.comments)} commentaires ont été ajoutés avec succès.")
 
     def __push_data_files(self) -> None:

--- a/tests/workflow/action/ConfigurationActionTestCase.py
+++ b/tests/workflow/action/ConfigurationActionTestCase.py
@@ -46,19 +46,28 @@ class ConfigurationActionTestCase(GpfTestCase):
                 o_mock_api_list.assert_called_once_with(infos_filter={"info": "val"}, tags_filter={"tag": "val"})
                 self.assertEqual(o_stored_data, o_c1)
 
-    def run_args(self, tags: Optional[Dict[str, Any]], comments: Optional[List[str]], config_already_exists: bool) -> None:
+    def run_args(
+        self,
+        tags: Optional[Dict[str, Any]],
+        comments: Optional[List[str]],
+        config_already_exists: bool,
+        comment_exist: bool = False,
+    ) -> None:
         """lancement +test de ConfigurationAction.run selon param
         Args:
             tags (Optional[Dict[str, Any]]): dict des tags ou None
             comments (Optional[List[str]]): liste des comments ou None
             config_already_exists (bool): configuration déjà existante
+            comment_exist (bool): si on a un commentaire qui existe déjà
         """
         # creation du dictionnaire qui reprend les paramètres du workflow pour créer une configuration
-        d_action = {"type": "configuration", "body_parameters": {"param": "valeur"}}
+        d_action: Dict[str, Any] = {"type": "configuration", "body_parameters": {"param": "valeur"}}
         if tags is not None:
             d_action["tags"] = tags
         if comments is not None:
-            d_action["comments"] = comments
+            d_action["comments"] = comments.copy()
+            if comment_exist:
+                d_action["comments"].append("commentaire existe")
 
         # initialisation de Configuration
         o_conf = ConfigurationAction("contexte", d_action)
@@ -66,6 +75,8 @@ class ConfigurationActionTestCase(GpfTestCase):
         # mock de configuration
         o_mock_configuration = MagicMock()
         o_mock_configuration.api_launch.return_value = None
+        o_mock_configuration.api_add_comment.return_value = None
+        o_mock_configuration.api_list_comments.return_value = [{"text": "commentaire existe"}] if comment_exist else []
 
         # Liste des configurations déjà existantes
         if config_already_exists:
@@ -95,9 +106,10 @@ class ConfigurationActionTestCase(GpfTestCase):
                     o_mock_configuration.api_add_tags.assert_not_called()
 
                 # test commentaires
-                if "comments" in d_action and d_action["comments"]:
-                    self.assertEqual(len(d_action["comments"]), o_mock_configuration.api_add_comment.call_count)
-                    for s_comm in d_action["comments"]:
+                if "comments" in d_action and comments:
+                    o_mock_configuration.api_list_comments.assert_called_once_with()
+                    self.assertEqual(len(comments), o_mock_configuration.api_add_comment.call_count)
+                    for s_comm in comments:
                         o_mock_configuration.api_add_comment.assert_any_call({"text": s_comm})
                 else:
                     o_mock_configuration.api_add_comment.assert_not_called()
@@ -107,10 +119,12 @@ class ConfigurationActionTestCase(GpfTestCase):
         # On teste avec et sans configuration renvoyé par api_list
         for b_config_already_exists in [True, False]:
             ## sans tag + sans commentaire
-            self.run_args(None, None, b_config_already_exists)
+            self.run_args(None, None, b_config_already_exists, False)
             ## tag vide + commentaire vide
-            self.run_args({}, [], b_config_already_exists)
+            self.run_args({}, [], b_config_already_exists, False)
             ## 1 tag + 1 commentaire
-            self.run_args({"tag1": "val1"}, ["comm1"], b_config_already_exists)
+            self.run_args({"tag1": "val1"}, ["comm1"], b_config_already_exists, False)
             ## 2 tag + 4 commentaire
-            self.run_args({"tag1": "val1", "tag2": "val2"}, ["comm1", "comm2", "comm3", "comm4"], b_config_already_exists)
+            self.run_args({"tag1": "val1", "tag2": "val2"}, ["comm1", "comm2", "comm3", "comm4"], b_config_already_exists, False)
+            ## 2 tag + 4 commentaire + 1 commentaire qui existe déjà
+            self.run_args({"tag1": "val1", "tag2": "val2"}, ["comm1", "comm2", "comm3", "comm4"], b_config_already_exists, True)

--- a/tests/workflow/action/UploadActionTestCase.py
+++ b/tests/workflow/action/UploadActionTestCase.py
@@ -76,15 +76,11 @@ class UploadActionTestCase(GpfTestCase):
         api_create: bool,
         api_delete: bool,
         run_fail: bool,
-        data_files: Dict[Path, str],
-        md5_files: List[Path],
-        upload_infos: Dict[str, Any],
-        tags: Dict[str, str],
-        comments: List[str],
         message_exception: Optional[str] = None,
         files_on_api: Dict[str, int] = {},
         nb_data_files_on_api_ok: int = 0,
         nb_md5_files_on_api_ok: int = 0,
+        comment_exist: bool = False,
     ) -> None:
         """Lance le test UploadAction.run selon un cas de figure. Faire varier les paramètres permet de jouer sur le cas testé.
         Args:
@@ -93,15 +89,11 @@ class UploadActionTestCase(GpfTestCase):
             api_create (bool): vérification de l'exécution de Upload.api_create (True => api_create exécuté; False => api_create non exécuté)
             api_delete (bool): vérification de l'exécution de Upload.api_delete (True => api_delete exécuté; False => api_delete non exécuté)
             run_fail (bool): vérification de l'exécution avec erreur de UploadAction.run (True => run plant; False => run s'exécute sans erreur)
-            data_files (Dict[Path, str]): fichiers de données
-            md5_files (List[Path]): fichiers de md5
-            upload_infos (Dict[str, Any]): informations de la livraison
-            tags (Dict[str, str]): tags à ajouter à la livraison
-            comments (List[str]): commentaires à ajouter à la livraison
             message_exception (Optional[str]): si run_fail==True le message d'erreur attendu
             files_on_api (Dict[str, int]): liste des fichiers déjà livrés sur l'API et leur taille (SIZE_OK si ok)
             nb_data_files_on_api_ok (int): nombre fichiers de données déjà livrés sur l'API et à ne pas re-livrer
             nb_md5_files_on_api_ok (int): nombre fichiers de clé déjà livrés sur l'API et à ne pas re-livrer
+            comment_exist (bool): si on a un commentaire qui existe déjà
         """
 
         def create(d_dict: Dict[str, Any]) -> Upload:
@@ -120,11 +112,19 @@ class UploadActionTestCase(GpfTestCase):
                 return "OPEN"
             raise Exception("cas non prévu", a, b)
 
+        l_return_api_list_comments = [{"text": "commentaire existe"}] if comment_exist else []
+        d_data_files : Dict[Path, str] = {Path("./a"): "a", Path("./b"): "b", Path("./c"): "c"}
+        l_md5_files: List[Path] = [Path("./a"), Path("./2")]
+        d_upload_infos: Dict[str, str] = {"_id": "upload_base", "name": "upload_name"}
+        d_tags: Dict[str, str] = {"tag1": "val1", "tag2": "val2"}
+        l_comments: List[str] = ["comm1", "comm2", "comm3"]
+
         with patch.object(UploadAction, "find_upload", return_value=return_value_find_upload) as o_mock_find_upload, \
             patch.object(Upload, "api_create", wraps=create) as o_mock_api_create, \
             patch.object(Upload, "api_close", MagicMock()) as o_mock_close, \
             patch.object(Upload, "api_delete", MagicMock()) as o_mock_api_delete, \
             patch.object(Upload, "api_add_tags", MagicMock()) as o_mock_api_add_tags, \
+            patch.object(Upload, "api_list_comments", return_value=l_return_api_list_comments) as o_mock_api_list_comments, \
             patch.object(Upload, "api_add_comment", MagicMock()) as o_mock_api_add_comment, \
             patch.object(Upload, "api_push_data_file", MagicMock()) as o_mock_api_push_data_file, \
             patch.object(Upload, "api_push_md5_file", MagicMock()) as o_mock_api_push_md5_file, \
@@ -138,11 +138,14 @@ class UploadActionTestCase(GpfTestCase):
             o_mock_path_stat.return_value.st_size = self.SIZE_OK
             # création du dataset
             o_mock_dataset = MagicMock()
-            o_mock_dataset.data_files = data_files
-            o_mock_dataset.md5_files = md5_files
-            o_mock_dataset.upload_infos = upload_infos
-            o_mock_dataset.tags = tags
-            o_mock_dataset.comments = comments
+            o_mock_dataset.data_files = d_data_files
+            o_mock_dataset.md5_files = l_md5_files
+            o_mock_dataset.upload_infos = d_upload_infos
+            o_mock_dataset.tags = d_tags
+            o_mock_dataset.comments = l_comments.copy()
+            if comment_exist:
+                o_mock_dataset.comments.append("commentaire existe")
+
             # exécution de UploadAction
             o_ua = UploadAction(o_mock_dataset, behavior)
             if run_fail:
@@ -157,7 +160,7 @@ class UploadActionTestCase(GpfTestCase):
 
             # vérif de o_mock_api_create
             if api_create:
-                o_mock_api_create.assert_called_once_with(upload_infos)
+                o_mock_api_create.assert_called_once_with(d_upload_infos)
             else:
                 o_mock_api_create.assert_not_called()
             # vérif de o_mock_api_delete
@@ -166,30 +169,31 @@ class UploadActionTestCase(GpfTestCase):
             else:
                 o_mock_api_delete.assert_not_called()
             # vérif de o_mock_api_add_tags
-            if tags is not None:
-                o_mock_api_add_tags.assert_called_once_with(tags)
+            if d_tags is not None:
+                o_mock_api_add_tags.assert_called_once_with(d_tags)
             else:
                 o_mock_api_add_tags.assert_not_called()
             # vérif de o_mock_api_add_comment
-            if comments is not None:
-                self.assertEqual(o_mock_api_add_comment.call_count, len(comments))
-                for s_comment in comments:
+            if l_comments is not None:
+                o_mock_api_list_comments.assert_called_once_with()
+                self.assertEqual(o_mock_api_add_comment.call_count, len(l_comments))
+                for s_comment in l_comments:
                     o_mock_api_add_comment.assert_any_call({"text": s_comment})
             else:
                 o_mock_api_add_comment.assert_not_called()
             # vérif de o_mock_api_push_data_file
             # appelée une fois par fichiers à livrer moins le nb de fichiers déjà livrés
-            self.assertEqual(o_mock_api_push_data_file.call_count, len(data_files) - nb_data_files_on_api_ok)
+            self.assertEqual(o_mock_api_push_data_file.call_count, len(d_data_files) - nb_data_files_on_api_ok)
             # appelée selon le Path des fichiers à livrer
-            for p_file_path, s_api_path in data_files.items():
+            for p_file_path, s_api_path in d_data_files.items():
                 # S'il ne sont pas déjà livrés et avec la bonne taille
                 if files_on_api.get(f"data/{s_api_path}") != self.SIZE_OK:
                     o_mock_api_push_data_file.assert_any_call(p_file_path, s_api_path)
             # vérif de o_mock_api_push_md5_file
             # appelée une fois par fichiers à livrer moins le nb de fichiers déjà livrés
-            self.assertEqual(o_mock_api_push_md5_file.call_count, len(md5_files) - nb_md5_files_on_api_ok)
+            self.assertEqual(o_mock_api_push_md5_file.call_count, len(l_md5_files) - nb_md5_files_on_api_ok)
             # appelée selon le Path des fichiers à livrer
-            for p_file_path in md5_files:
+            for p_file_path in l_md5_files:
                 # S'il ne sont pas déjà livrés et avec la bonne taille
                 if files_on_api.get(p_file_path.name) != self.SIZE_OK:
                     o_mock_api_push_md5_file.assert_any_call(p_file_path)
@@ -202,27 +206,17 @@ class UploadActionTestCase(GpfTestCase):
 
     def test_run(self) -> None:
         """Lance le test de UploadAction.run selon plusieurs cas de figures."""
+        # tout mode sans doublon
         self.run_args(
             behavior=None,
             return_value_find_upload=None,
-            data_files={Path("./a"): "a", Path("./b"): "b", Path("./c"): "c"},
-            md5_files=[Path("./a"), Path("./2")],
-            upload_infos={"_id": "upload_base", "name": "upload_name"},
-            tags={"tag1": "val1", "tag2": "val2"},
-            comments=["comm1", "comm2", "comm3"],
             api_create=True,
             api_delete=False,
             run_fail=False,
         )
-        # tout mode sans doublon
         self.run_args(
             behavior="STOP",
             return_value_find_upload=None,
-            data_files={Path("./a"): "a", Path("./b"): "b", Path("./c"): "c"},
-            md5_files=[Path("./a"), Path("./2")],
-            upload_infos={"_id": "upload_base", "name": "upload_name"},
-            tags={"tag1": "val1", "tag2": "val2"},
-            comments=["comm1", "comm2", "comm3"],
             api_create=True,
             api_delete=False,
             run_fail=False,
@@ -230,11 +224,6 @@ class UploadActionTestCase(GpfTestCase):
         self.run_args(
             behavior="DELETE",
             return_value_find_upload=None,
-            data_files={Path("./a"): "a", Path("./b"): "b", Path("./c"): "c"},
-            md5_files=[Path("./a"), Path("./2")],
-            upload_infos={"_id": "upload_base", "name": "upload_name"},
-            tags={"tag1": "val1", "tag2": "val2"},
-            comments=["comm1", "comm2", "comm3"],
             api_create=True,
             api_delete=False,
             run_fail=False,
@@ -242,11 +231,6 @@ class UploadActionTestCase(GpfTestCase):
         self.run_args(
             behavior="CONTINUE",
             return_value_find_upload=None,
-            data_files={Path("./a"): "a", Path("./b"): "b", Path("./c"): "c"},
-            md5_files=[Path("./a"), Path("./2")],
-            upload_infos={"_id": "upload_base", "name": "upload_name"},
-            tags={"tag1": "val1", "tag2": "val2"},
-            comments=["comm1", "comm2", "comm3"],
             api_create=True,
             api_delete=False,
             run_fail=False,
@@ -257,11 +241,6 @@ class UploadActionTestCase(GpfTestCase):
         self.run_args(
             behavior="STOP",
             return_value_find_upload=o_return_value_find_upload,
-            data_files={Path("./a"): "a", Path("./b"): "b", Path("./c"): "c"},
-            md5_files=[Path("./a"), Path("./2")],
-            upload_infos={"_id": "upload_base", "name": "upload_name"},
-            tags={"tag1": "val1", "tag2": "val2"},
-            comments=["comm1", "comm2", "comm3"],
             api_create=True,
             api_delete=False,
             run_fail=True,
@@ -270,12 +249,7 @@ class UploadActionTestCase(GpfTestCase):
         # mode DELETE mais avec doublon => suppression mais OK
         self.run_args(
             behavior="DELETE",
-            return_value_find_upload = Upload({"_id": "upload_existant", "name": "Upload existant", "status": "OPEN"}),
-            data_files={Path("./a"): "a", Path("./b"): "b", Path("./c"): "c"},
-            md5_files=[Path("./a"), Path("./2")],
-            upload_infos={"_id": "upload_base", "name": "upload_name"},
-            tags={"tag1": "val1", "tag2": "val2"},
-            comments=["comm1", "comm2", "comm3"],
+            return_value_find_upload = o_return_value_find_upload,
             api_create=True,
             api_delete=True,
             run_fail=False,
@@ -284,15 +258,20 @@ class UploadActionTestCase(GpfTestCase):
         # mode CONTINUE mais avec doublon (ouvert) => pas suppression ni création
         self.run_args(
             behavior="CONTINUE",
-            return_value_find_upload = Upload({"_id": "upload_existant", "name": "Upload existant", "status": "OPEN"}),
-            data_files={Path("./a"): "a", Path("./b"): "b", Path("./c"): "c"},
-            md5_files=[Path("./a"), Path("./2")],
-            upload_infos={"_id": "upload_base", "name": "upload_name"},
-            tags={"tag1": "val1", "tag2": "val2"},
-            comments=["comm1", "comm2", "comm3"],
+            return_value_find_upload = o_return_value_find_upload,
             api_create=False,
             api_delete=False,
             run_fail=False,
+        )
+
+        # mode CONTINUE mais avec doublon (ouvert) et commentaire déjà présent
+        self.run_args(
+            behavior="CONTINUE",
+            return_value_find_upload = o_return_value_find_upload,
+            api_create=False,
+            api_delete=False,
+            run_fail=False,
+            comment_exist=True
         )
 
         # mode CONTINUE mais avec doublon (fermé) => ça plante
@@ -300,11 +279,6 @@ class UploadActionTestCase(GpfTestCase):
         self.run_args(
             behavior="CONTINUE",
             return_value_find_upload=o_return_value_find_upload,
-            data_files={Path("./a"): "a", Path("./b"): "b", Path("./c"): "c"},
-            md5_files=[Path("./a"), Path("./2")],
-            upload_infos={"_id": "upload_base", "name": "upload_name"},
-            tags={"tag1": "val1", "tag2": "val2"},
-            comments=["comm1", "comm2", "comm3"],
             api_create=False,
             api_delete=False,
             run_fail=True,


### PR DESCRIPTION
Pour les reprises de livraison et de configurations : les commentaires déjà présent ne sont plus rajoutés.

Processing-execution : le problème ne se pose pas => il n'y a pas de mode continue.